### PR TITLE
Changes to checkout repo step

### DIFF
--- a/.github/workflows/fetch_past_weather_data.yaml
+++ b/.github/workflows/fetch_past_weather_data.yaml
@@ -40,7 +40,7 @@ jobs:
           python src/data_fetch_scripts/fetch_weather_data.py
 
       - name: Pull changes from remote branch
-        run: git pull origin data_updates_weather_data
+        run: git pull data_updates_weather_data
 
       # - name: Commit and Push results to data_updates_weather_data branch
       #   run: |

--- a/.github/workflows/fetch_past_weather_data.yaml
+++ b/.github/workflows/fetch_past_weather_data.yaml
@@ -42,10 +42,10 @@ jobs:
       - name: Pull changes from remote branch
         run: git pull origin data_updates_weather_data
 
-      - name: Commit and Push results to data_updates_weather_data branch
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "Data update ${{ steps.get_date.outputs.date}}"
-          git push origin HEAD:data_updates_weather_data
+      # - name: Commit and Push results to data_updates_weather_data branch
+      #   run: |
+      #     git config user.name github-actions
+      #     git config user.email github-actions@github.com
+      #     git add .
+      #     git commit -m "Data update ${{ steps.get_date.outputs.date}}"
+      #     git push origin HEAD:data_updates_weather_data

--- a/.github/workflows/fetch_past_weather_data.yaml
+++ b/.github/workflows/fetch_past_weather_data.yaml
@@ -18,9 +18,10 @@ jobs:
         run: echo "date=$(date +'%d-%m-%Y')" >> $GITHUB_OUTPUT
 
       - name: Checkout repo content
-        uses: actions/checkout@v3 # checkout the repository content to github runner
+        uses: actions/checkout@v4 # checkout the repository content to github runner
         with:
           lfs: True
+          fetch-depth: 0
 
       - name: Pull LFS objects
         run: git lfs pull
@@ -40,7 +41,7 @@ jobs:
           python src/data_fetch_scripts/fetch_weather_data.py
 
       - name: Pull changes from remote branch
-        run: git pull data_updates_weather_data
+        run: git pull origin data_updates_weather_data
 
       # - name: Commit and Push results to data_updates_weather_data branch
       #   run: |


### PR DESCRIPTION
This [actions/checkout issue](https://github.com/actions/checkout/issues/125) suggests way to deal with _fatal: refusing to merge unrelated histories_
Added `fetch-depth: 0` to see if it resolves the problem at the _pull_changes_ stage