### PR TITLE
Uncommented push step in fetch_past_weather_data

### DIFF
--- a/.github/workflows/fetch_past_weather_data.yaml
+++ b/.github/workflows/fetch_past_weather_data.yaml
@@ -43,10 +43,10 @@ jobs:
       - name: Pull changes from remote branch
         run: git pull origin data_updates_weather_data
 
-      # - name: Commit and Push results to data_updates_weather_data branch
-      #   run: |
-      #     git config user.name github-actions
-      #     git config user.email github-actions@github.com
-      #     git add .
-      #     git commit -m "Data update ${{ steps.get_date.outputs.date}}"
-      #     git push origin HEAD:data_updates_weather_data
+      - name: Commit and Push results to data_updates_weather_data branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Data update ${{ steps.get_date.outputs.date}}"
+          git push origin HEAD:data_updates_weather_data


### PR DESCRIPTION
`fetch-depth: 0` worked when running the action from the _develop_ branch and using `git pull origin data_updates_weather_data`. Time to run the whole action and push fetched data