### PR TITLE
Fixed bug in transform_weather_data.py

### DIFF
--- a/data/weather_data/3316_crosby_weather_data_transformed.parquet
+++ b/data/weather_data/3316_crosby_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51e724a06130313f61c96bdab645865c0fb11edea1eaa76510864dad18296d33
-size 24883
+oid sha256:de68cb9a7917e4d8af1da6640522b998f1eba44d37ac974be8f70903ad7ff899
+size 37455

--- a/data/weather_data/3344_bingley_samos_weather_data_transformed.parquet
+++ b/data/weather_data/3344_bingley_samos_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7aafaaca7131d712ef651929db9ac9e779aef62c383d31f5f90276f658ee947
-size 25351
+oid sha256:5af694e5bd8d1107bfc66df4123eaa0c52fc9dfa7d5cda0ac787f3fbd7645c70
+size 37948

--- a/data/weather_data/3351_rostherne_no_2_weather_data_transformed.parquet
+++ b/data/weather_data/3351_rostherne_no_2_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c77b521b212fb0213b2623b89377e2333499a7c85f25530cf13f63217bca42b
-size 25418
+oid sha256:ccba5c5422e42f3daf630f9ce1afe67311d945758a82a8f0cdd930b5eed38321
+size 37953

--- a/data/weather_data/3354_watnall_weather_data_transformed.parquet
+++ b/data/weather_data/3354_watnall_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f3b6b966b391db4af7d2d38c9e02b9b0d6cd28861a2609c92fb70c06b8bc22d
-size 25388
+oid sha256:490bc5b866795c1925f82ad1b061a379088f0c88d2b88f4367fa533534dd022c
+size 38029

--- a/data/weather_data/3535_coleshill_weather_data_transformed.parquet
+++ b/data/weather_data/3535_coleshill_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0996ad110ef96851fd59e4cd5ee50a26c1cdc1a709383f477d12e1792e534a17
-size 25309
+oid sha256:052eef8c9dff7cc27553fef8ab78f155dffb9db3807dd08fcf18b86429671359
+size 37885

--- a/data/weather_data/3772_heathrow_weather_data_transformed.parquet
+++ b/data/weather_data/3772_heathrow_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dec91fcba3d1cb1f8af5cf88b12db6f486ff6e442811ad82170bcfed15b0fdd9
-size 25345
+oid sha256:41a159f9e0a3ae90c7f3cbee51f57690e185f9e68818185a24575bceba8405fc
+size 37913

--- a/data/weather_data/3872_thorney_island_weather_data_transformed.parquet
+++ b/data/weather_data/3872_thorney_island_weather_data_transformed.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:208972e44e7b83c24477a4db2e62ce2f07fa79c80d0c822c661a3268aba9b917
-size 25272
+oid sha256:887afa84c6ce95b2ddbb7e717a76ad23f5d70078c9ce6550656908bf3ce92c0c
+size 37755

--- a/data/weather_data/weather_data_combined.parquet
+++ b/data/weather_data/weather_data_combined.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74f438977a88b615ba64e1cd6449a39c6540b5683536ea09dc31f37bae961b72
-size 32556
+oid sha256:5f73772b3e5670469fd7b040cba0f7e9de61ef30e5e25220f74615e80ec6979d
+size 51515

--- a/src/data_transform_scripts/transform_weather_data.py
+++ b/src/data_transform_scripts/transform_weather_data.py
@@ -31,7 +31,7 @@ def main(current_dir: str) -> None:
     # Extract filenames from data directory
     sorted_filenames = sorted(
         [file.split(".")[0] for file in os.listdir(os.path.normpath(data_dir))
-         if ".parquet" in file and "transformed" not in file]
+         if ".parquet" in file and "transformed" not in file and "combined" not in file]
     )
     # Transform data from the individual locations and save it to a new parquet file
     for file in sorted_filenames:


### PR DESCRIPTION
## Description of changes
Fixed bug on _transform_weather_data.py_ which failed to transform individual parquet files if the _weather_data_combined.parquet_ file is present in the directory

## Checklist
- [x] Running _trasnsform_weather_data.py_ works
- [x] The right data is stored after running the script

## Description of testing
The changes were tested by running _transform_weather_data.py_